### PR TITLE
Increase Luminosity of Usernames

### DIFF
--- a/app/models/message.coffee
+++ b/app/models/message.coffee
@@ -22,7 +22,11 @@ Message = DS.Model.extend
   # Rendering/Display properties.
   style: (->
     color = @get 'color'
-    "color: #{color}"
+    for i in [0..2]
+      h = parseInt(color.substr(i * 2, 2), 16)
+      h = Math.round(Math.min(Math.max(0, h + (h * 0.5)), 255)).toString(16)
+      rgb += ("00" + h).substr(h.length)
+    "color: #{rgb}"
   ).property('color')
 
   # Is this message purged?


### PR DESCRIPTION
Function adapted from http://www.sitepoint.com/javascript-generate-lighter-darker-color/ , I presume that 50% lighter is a good starting point ( the 0.5 in https://github.com/VxJasonxV/avalonstar-live/blob/5c1dffeed145be2d42f317bf6e07b5106a12466e/app/models/message.coffee#L27 ), but it definitely needs to be evaluated, and I have no idea what the best way to accomplish that is.

coffeelint isn't complaining, but that doesn't mean much.
